### PR TITLE
feat: Add support for AWS Bedrock foundation model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-bedrockruntime"
+version = "1.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa1d54e1253e3739bfa6d60df813a093b916971fc423aa90fee9ca607438a177"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-dynamodb"
 version = "1.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,11 +878,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef7d0a272725f87e51ba2bf89f8c21e4df61b9e49ae1ac367a6d69916ef7c90"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.60.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -939,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.9"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd94a32b3a7d55d3806fe27d98d3ad393050439dd05eb53ece36ec5e3d3510"
+checksum = "c7b8a53819e42f10d0821f56da995e1470b199686a1809168db6ca485665f042"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -6401,6 +6436,24 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rig-bedrock"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aws-config",
+ "aws-sdk-bedrockruntime",
+ "aws-smithy-types",
+ "rig-core",
+ "rig-derive",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ members = [
     "rig-core/rig-core-derive",
     "rig-sqlite",
     "rig-eternalai",
+    "rig-bedrock",
 ]

--- a/rig-bedrock/Cargo.toml
+++ b/rig-bedrock/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "rig-bedrock"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+readme = "README.md"
+description = "AWS Bedrock model provider for Rig integration."
+
+[dependencies]
+rig-core = { path = "../rig-core", version = "0.7.0" }
+rig-derive = { path = "../rig-core/rig-core-derive", version = "0.1.0" }
+serde = { version = "1.0.193", features = ["derive"] }
+serde_json = "1.0.108"
+schemars = "0.8.16"
+tracing = "0.1.40"
+aws-config = { version = "1.5.8", features = ["behavior-version-latest"] }
+aws-sdk-bedrockruntime = "1.53.0"
+aws-smithy-types = "1.2.12"
+
+[dev-dependencies]
+anyhow = "1.0.75"
+tokio = { version = "1.34.0", features = ["full"] }
+tracing-subscriber = "0.3.18"

--- a/rig-bedrock/README.md
+++ b/rig-bedrock/README.md
@@ -1,0 +1,21 @@
+## Rig-Bedrock
+This companion crate integrates AWS Bedrock as model provider with Rig.
+
+## Usage
+
+Add the companion crate to your `Cargo.toml`, along with the rig-core crate:
+
+```toml
+[dependencies]
+rig-bedrock = "0.1.0"
+rig-core = "0.7.0"
+```
+
+You can also run `cargo add rig-bedrock rig-core` to add the most recent versions of the dependencies to your project.
+
+See the [`/examples`](./examples) folder for usage examples.
+
+Make sure to have AWS credentials env vars loaded before starting client such as:
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_SECRET_ACCESS_KEY=.......
+export AWS_ACCESS_KEY_ID=......

--- a/rig-bedrock/examples/agent_with_bedrock.rs
+++ b/rig-bedrock/examples/agent_with_bedrock.rs
@@ -1,0 +1,185 @@
+use std::{
+    error::Error,
+    fmt::{Display, Formatter},
+};
+
+use rig::{
+    agent::AgentBuilder,
+    completion::{Prompt, ToolDefinition},
+    loaders::FileLoader,
+    tool::Tool,
+};
+use rig_bedrock::client::{BedrockModel, Client, ClientBuilder};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tracing::info;
+
+#[derive(Deserialize)]
+struct OperationArgs {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MathError {
+    Reason(&'static str),
+}
+
+impl Display for MathError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use MathError::*;
+        match self {
+            Reason(err) => write!(f, "Math error: {}", err),
+        }
+    }
+}
+
+impl Error for MathError {}
+
+#[derive(Deserialize, Serialize)]
+struct Adder;
+impl Tool for Adder {
+    const NAME: &'static str = "add";
+
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "add".to_string(),
+            description: "Add x and y together".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The first number to add"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The second number to add"
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let result = args.x + args.y;
+        Ok(result)
+    }
+}
+
+/// Runs 4 agents based on AWS Bedrock (dervived from the agent_with_grok example)
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .init();
+
+    info!("Running basic agent");
+    basic().await?;
+
+    info!("\nRunning agent with tools");
+    tools().await?;
+
+    info!("\nRunning agent with loaders");
+    loaders().await?;
+
+    info!("\nRunning agent with context");
+    context().await?;
+
+    info!("\n\nAll agents ran successfully");
+    Ok(())
+}
+
+async fn client() -> Client {
+    ClientBuilder::new().build().await
+}
+
+async fn partial_agent() -> AgentBuilder<rig_bedrock::completion::CompletionModel> {
+    let client = client().await;
+    client.agent(BedrockModel::NovaLite)
+}
+
+/// Create an AWS Bedrock agent with a system prompt
+async fn basic() -> Result<(), anyhow::Error> {
+    let agent = partial_agent()
+        .await
+        .preamble("Answer with json format only")
+        .build();
+
+    let response = agent.prompt("Describe solar system").await?;
+    info!("{}", response);
+
+    Ok(())
+}
+
+/// Create an AWS Bedrock with tools
+async fn tools() -> Result<(), anyhow::Error> {
+    let calculator_agent = partial_agent()
+        .await
+        .preamble("You must only do math by using a tool.")
+        .max_tokens(1024)
+        .tool(Adder)
+        .build();
+
+    info!(
+        "Calculator Agent: add 400 and 20\nResult: {}",
+        calculator_agent.prompt("add 400 and 20").await?
+    );
+
+    Ok(())
+}
+
+async fn context() -> Result<(), anyhow::Error> {
+    let model = client().await.completion_model(BedrockModel::NovaLite);
+
+    // Create an agent with multiple context documents
+    let agent = AgentBuilder::new(model)
+        .preamble("Answer the question")
+        .context("Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets")
+        .context("Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.")
+        .context("Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.")
+        .build();
+
+    // Prompt the agent and print the response
+    let response = agent.prompt("What does \"glarb-glarb\" mean?").await?;
+
+    info!("What does \"glarb-glarb\" mean?\n{}", response);
+
+    Ok(())
+}
+
+/// Based upon the `loaders` example
+///
+/// This example loads in all the rust examples from the rig-core crate and uses them as\\
+///  context for the agent
+async fn loaders() -> Result<(), anyhow::Error> {
+    let model = client().await.completion_model(BedrockModel::NovaLite);
+
+    // Load in all the rust examples
+    let examples = FileLoader::with_glob("rig-core/examples/*.rs")?
+        .read_with_path()
+        .ignore_errors()
+        .into_iter();
+
+    // Create an agent with multiple context documents
+    let agent = examples
+        .fold(AgentBuilder::new(model), |builder, (path, content)| {
+            builder.context(format!("Rust Example {:?}:\n{}", path, content).as_str())
+        })
+        .preamble("Answer the question")
+        .build();
+
+    // Prompt the agent and print the response
+    let response = agent
+        .prompt("Which rust example is best suited for the operation 1 + 2")
+        .await?;
+
+    info!("{}", response);
+
+    Ok(())
+}

--- a/rig-bedrock/examples/embedding_with_bedrock.rs
+++ b/rig-bedrock/examples/embedding_with_bedrock.rs
@@ -1,0 +1,35 @@
+use rig::Embed;
+use rig_bedrock::client::ClientBuilder;
+use rig_bedrock::embedding::BedrockEmbeddingModel;
+use tracing::info;
+
+#[derive(rig_derive::Embed, Debug)]
+struct Greetings {
+    #[embed]
+    message: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .init();
+
+    let client = ClientBuilder::new().build().await;
+
+    let embeddings = client
+        .embeddings(BedrockEmbeddingModel::TitanTextEmbeddingsV2(256))
+        .document(Greetings {
+            message: "aa".to_string(),
+        })?
+        .document(Greetings {
+            message: "bb".to_string(),
+        })?
+        .build()
+        .await?;
+
+    info!("{:?}", embeddings);
+
+    Ok(())
+}

--- a/rig-bedrock/examples/extractor_with_bedrock.rs
+++ b/rig-bedrock/examples/extractor_with_bedrock.rs
@@ -1,0 +1,32 @@
+use rig_bedrock::client::{BedrockModel, ClientBuilder};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
+struct Person {
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub job: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .init();
+
+    let client = ClientBuilder::new().build().await;
+
+    let data_extractor = client.extractor::<Person>(BedrockModel::NovaLite).build();
+    let person = data_extractor
+        .extract("Hello my name is John Doe! I am a software engineer.")
+        .await?;
+
+    info!(
+        "AWS Bedrock: {}",
+        serde_json::to_string_pretty(&person).unwrap()
+    );
+    Ok(())
+}

--- a/rig-bedrock/examples/rag_with_bedrock.rs
+++ b/rig-bedrock/examples/rag_with_bedrock.rs
@@ -1,0 +1,86 @@
+use std::vec;
+
+use rig::{
+    completion::Prompt, embeddings::EmbeddingsBuilder,
+    vector_store::in_memory_store::InMemoryVectorStore, Embed,
+};
+use rig_bedrock::{
+    client::{BedrockModel, ClientBuilder},
+    embedding::BedrockEmbeddingModel,
+};
+use serde::Serialize;
+use tracing::info;
+
+// Data to be RAGged.
+// A vector search needs to be performed on the `definitions` field, so we derive the `Embed` trait for `WordDefinition`
+// and tag that field with `#[embed]`.
+#[derive(rig_derive::Embed, Serialize, Clone, Debug, Eq, PartialEq, Default)]
+struct WordDefinition {
+    id: String,
+    word: String,
+    #[embed]
+    definitions: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .init();
+
+    let client = ClientBuilder::new().build().await;
+    let embedding_model = client.embedding_model(BedrockEmbeddingModel::TitanTextEmbeddingsV2(256));
+
+    // Generate embeddings for the definitions of all the documents using the specified embedding model.
+    let embeddings = EmbeddingsBuilder::new(embedding_model.clone())
+        .documents(vec![
+            WordDefinition {
+                id: "doc0".to_string(),
+                word: "flurbo".to_string(),
+                definitions: vec![
+                    "1. *flurbo* (name): A flurbo is a green alien that lives on cold planets.".to_string(),
+                    "2. *flurbo* (name): A fictional digital currency that originated in the animated series Rick and Morty.".to_string()
+                ]
+            },
+            WordDefinition {
+                id: "doc1".to_string(),
+                word: "glarb-glarb".to_string(),
+                definitions: vec![
+                    "1. *glarb-glarb* (noun): A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+                    "2. *glarb-glarb* (noun): A fictional creature found in the distant, swampy marshlands of the planet Glibbo in the Andromeda galaxy.".to_string()
+                ]
+            },
+            WordDefinition {
+                id: "doc2".to_string(),
+                word: "linglingdong".to_string(),
+                definitions: vec![
+                    "1. *linglingdong* (noun): A term used by inhabitants of the far side of the moon to describe humans.".to_string(),
+                    "2. *linglingdong* (noun): A rare, mystical instrument crafted by the ancient monks of the Nebulon Mountain Ranges on the planet Quarm.".to_string()
+                ]
+            },
+        ])?
+        .build()
+        .await?;
+
+    // Create vector store with the embeddings
+    let vector_store = InMemoryVectorStore::from_documents(embeddings);
+
+    // Create vector store index
+    let index = vector_store.index(embedding_model);
+
+    let rag_agent = client.agent(BedrockModel::NovaLite)
+        .preamble("
+            You are a dictionary assistant here to assist the user in understanding the meaning of words.
+            You will find additional non-standard word definitions that could be useful below.
+        ")
+        .dynamic_context(1, index)
+        .build();
+
+    // Prompt the agent and print the response
+    let response = rag_agent.prompt("What does \"glarb-glarb\" mean?").await?;
+
+    info!("{}", response);
+
+    Ok(())
+}

--- a/rig-bedrock/src/client.rs
+++ b/rig-bedrock/src/client.rs
@@ -1,0 +1,100 @@
+use aws_config::{BehaviorVersion, Region};
+use rig::{agent::AgentBuilder, embeddings, extractor::ExtractorBuilder, Embed};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    completion::CompletionModel,
+    embedding::{BedrockEmbeddingModel, EmbeddingModel},
+};
+
+pub enum BedrockModel {
+    NovaLite,
+    Mistral8x7BInstruct,
+    Custom(&'static str),
+}
+// ================================================================
+// All supported models: https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
+// ================================================================
+impl BedrockModel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BedrockModel::NovaLite => "amazon.nova-lite-v1:0",
+            BedrockModel::Mistral8x7BInstruct => "mistral.mixtral-8x7b-instruct-v0:1",
+            BedrockModel::Custom(str) => str,
+        }
+    }
+}
+
+// Important: make sure to verify model and region compatibility: https://docs.aws.amazon.com/bedrock/latest/userguide/models-regions.html
+pub const DEFAULT_AWS_REGION: &str = "us-east-1";
+
+#[derive(Clone)]
+pub struct ClientBuilder<'a> {
+    region: &'a str,
+}
+
+/// Create a new Bedrock client using the builder
+///
+/// #(Make sure you have permissions to access Amazon Bedrock foundation model)
+/// [https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html]
+impl<'a> ClientBuilder<'a> {
+    pub fn new() -> Self {
+        Self {
+            region: DEFAULT_AWS_REGION,
+        }
+    }
+
+    pub fn region(mut self, region: &'a str) -> Self {
+        self.region = region;
+        self
+    }
+
+    pub async fn build(self) -> Client {
+        let sdk_config = aws_config::defaults(BehaviorVersion::latest())
+            .region(Region::new(String::from(self.region)))
+            .load()
+            .await;
+        let client = aws_sdk_bedrockruntime::Client::new(&sdk_config);
+        Client { aws_client: client }
+    }
+}
+
+impl<'a> Default for ClientBuilder<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone)]
+pub struct Client {
+    pub(crate) aws_client: aws_sdk_bedrockruntime::Client,
+}
+
+impl Client {
+    pub fn completion_model(&self, model: BedrockModel) -> CompletionModel {
+        CompletionModel::new(self.clone(), model.as_str())
+    }
+
+    pub fn agent(&self, model: BedrockModel) -> AgentBuilder<CompletionModel> {
+        AgentBuilder::new(self.completion_model(model))
+    }
+
+    pub fn embedding_model(&self, model: BedrockEmbeddingModel) -> EmbeddingModel {
+        EmbeddingModel::new(self.clone(), model)
+    }
+
+    pub fn extractor<T: JsonSchema + for<'a> Deserialize<'a> + Serialize + Send + Sync>(
+        &self,
+        model: BedrockModel,
+    ) -> ExtractorBuilder<T, CompletionModel> {
+        ExtractorBuilder::new(self.completion_model(model))
+    }
+
+    pub fn embeddings<D: Embed>(
+        &self,
+        model: BedrockEmbeddingModel,
+    ) -> embeddings::EmbeddingsBuilder<EmbeddingModel, D> {
+        embeddings::EmbeddingsBuilder::new(self.embedding_model(model))
+    }
+}

--- a/rig-bedrock/src/completion.rs
+++ b/rig-bedrock/src/completion.rs
@@ -1,0 +1,166 @@
+use std::str::FromStr;
+
+use crate::{client::Client, document_to_json, json_to_document};
+use aws_sdk_bedrockruntime::{
+    operation::converse::ConverseError,
+    types::{
+        ContentBlock, ConversationRole, ConverseOutput, InferenceConfiguration, Message,
+        SystemContentBlock, Tool, ToolConfiguration, ToolInputSchema, ToolSpecification,
+    },
+};
+use rig::completion::{self, CompletionError};
+
+#[derive(Clone)]
+pub struct CompletionModel {
+    client: Client,
+    model_id: &'static str,
+}
+
+impl CompletionModel {
+    pub fn new(client: Client, model_id: &'static str) -> Self {
+        Self { client, model_id }
+    }
+}
+
+impl completion::CompletionModel for CompletionModel {
+    type Response = ConverseOutput;
+
+    async fn completion(
+        &self,
+        mut completion_request: completion::CompletionRequest,
+    ) -> Result<completion::CompletionResponse<ConverseOutput>, CompletionError> {
+        let mut full_history = Vec::new();
+        full_history.append(&mut completion_request.chat_history);
+        full_history.push(completion::Message {
+            role: "user".into(),
+            content: completion_request.prompt_with_context(),
+        });
+
+        let prompt_with_history = full_history
+            .into_iter()
+            .filter_map(|m| {
+                let role = ConversationRole::from_str(&m.role).unwrap_or(ConversationRole::User);
+                Message::builder()
+                    .role(role)
+                    .content(ContentBlock::Text(completion_request.prompt_with_context()))
+                    .build()
+                    .ok()
+            })
+            .collect::<Vec<_>>();
+
+        let mut converse_builder = self.client.aws_client.converse().model_id(self.model_id);
+        let mut inference_configuration = InferenceConfiguration::builder();
+
+        if let Some(params) = completion_request.additional_params {
+            converse_builder = converse_builder
+                .set_additional_model_request_fields(Some(json_to_document(params)));
+        }
+
+        if let Some(temperature) = completion_request.temperature {
+            inference_configuration =
+                inference_configuration.set_temperature(Some(temperature as f32));
+        }
+
+        if let Some(max_tokens) = completion_request.max_tokens {
+            inference_configuration =
+                inference_configuration.set_max_tokens(Some(max_tokens as i32));
+        }
+
+        converse_builder =
+            converse_builder.set_inference_config(Some(inference_configuration.build()));
+
+        let mut tools = vec![];
+        for tool_definition in completion_request.tools.iter() {
+            let document = json_to_document(tool_definition.parameters.clone());
+            let schema = ToolInputSchema::Json(document);
+            let tool = Tool::ToolSpec(
+                ToolSpecification::builder()
+                    .name(tool_definition.name.clone())
+                    .set_description(Some(tool_definition.description.clone()))
+                    .set_input_schema(Some(schema))
+                    .build()
+                    .map_err(|e| CompletionError::RequestError(e.into()))?,
+            );
+            tools.push(tool);
+        }
+
+        if !tools.is_empty() {
+            let config = ToolConfiguration::builder()
+                .set_tools(Some(tools))
+                .build()
+                .map_err(|e| CompletionError::RequestError(e.into()))?;
+
+            converse_builder = converse_builder.set_tool_config(Some(config));
+        }
+
+        if let Some(system_prompt) = completion_request.preamble {
+            converse_builder =
+                converse_builder.set_system(Some(vec![SystemContentBlock::Text(system_prompt)]));
+        }
+
+        let model_response = converse_builder
+            .set_messages(Some(prompt_with_history))
+            .send()
+            .await;
+
+        let response = model_response
+            .map_err(|sdk_error| if let Some(service_error) = sdk_error.as_service_error() {
+                let err: String = match service_error {
+                    ConverseError::ModelTimeoutException(e) => e.to_owned().message.unwrap_or("The request took too long to process. Processing time exceeded the model timeout length.".into()),
+                    ConverseError::AccessDeniedException(e) => e.to_owned().message.unwrap_or("The request is denied because you do not have sufficient permissions to perform the requested action.".into()),
+                    ConverseError::ResourceNotFoundException(e) => e.to_owned().message.unwrap_or("The specified resource ARN was not found.".into()),
+                    ConverseError::ThrottlingException(e) => e.to_owned().message.unwrap_or("Your request was denied due to exceeding the account quotas for AWS Bedrock.".into()),
+                    ConverseError::ServiceUnavailableException(e) => e.to_owned().message.unwrap_or("The service isn't currently available.".into()),
+                    ConverseError::InternalServerException(e) => e.to_owned().message.unwrap_or("An internal server error occurred.".into()),
+                    ConverseError::ValidationException(e) => e.to_owned().message.unwrap_or("The input fails to satisfy the constraints specified by AWS Bedrock.".into()),
+                    ConverseError::ModelNotReadyException(e) => e.to_owned().message.unwrap_or("The model specified in the request is not ready to serve inference requests. The AWS SDK will automatically retry the operation up to 5 times.".into()),
+                    ConverseError::ModelErrorException(e) => e.to_owned().message.unwrap_or("The request failed due to an error while processing the model.".into()),
+                    _ => String::from("An unexpected error occurred (e.g., invalid JSON returned by the service or an unknown error code).")
+                };
+                CompletionError::ProviderError(err)
+            } else {
+                CompletionError::ProviderError(format!("{:?}", sdk_error))
+            })?;
+
+        let response = response.output.ok_or(CompletionError::ProviderError(
+            "Model didn't return any converse output".into(),
+        ))?;
+
+        let content_blocks = response
+            .as_message()
+            .map_err(|_| {
+                CompletionError::ProviderError(
+                    "Failed to extract message from converse output".into(),
+                )
+            })?
+            .content();
+
+        if let Some(tool_use) = content_blocks.iter().find_map(|content| match content {
+            ContentBlock::ToolUse(tool_use_block) => Some(tool_use_block.to_owned()),
+            _ => None,
+        }) {
+            return Ok(completion::CompletionResponse {
+                choice: completion::ModelChoice::ToolCall(
+                    tool_use.name,
+                    tool_use.tool_use_id,
+                    document_to_json(tool_use.input),
+                ),
+                raw_response: response,
+            });
+        }
+
+        if let Some(text) = content_blocks.iter().find_map(|content| match content {
+            ContentBlock::Text(text) => Some(text.to_owned()),
+            _ => None,
+        }) {
+            return Ok(completion::CompletionResponse {
+                choice: completion::ModelChoice::Message(text),
+                raw_response: response,
+            });
+        }
+
+        Err(CompletionError::ResponseError(
+            "Response did not contain a message or tool call".into(),
+        ))
+    }
+}

--- a/rig-bedrock/src/embedding.rs
+++ b/rig-bedrock/src/embedding.rs
@@ -1,0 +1,140 @@
+use aws_sdk_bedrockruntime::operation::invoke_model::*;
+use aws_smithy_types::Blob;
+use rig::embeddings::{self, Embedding, EmbeddingError};
+use serde::{Deserialize, Serialize};
+
+use crate::client::Client;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EmbeddingRequest {
+    pub input_text: String,
+    pub dimensions: usize,
+    pub normalize: bool,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct EmbeddingResponse {
+    pub embedding: Vec<f64>,
+    pub input_text_token_count: usize,
+}
+
+#[derive(Clone)]
+pub enum BedrockEmbeddingModel {
+    TitanTextEmbeddingsV2(usize),
+    Custom(&'static str, usize),
+}
+
+impl BedrockEmbeddingModel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BedrockEmbeddingModel::TitanTextEmbeddingsV2(_) => "amazon.titan-embed-text-v2:0",
+            BedrockEmbeddingModel::Custom(str, _) => str,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct EmbeddingModel {
+    client: Client,
+    model: BedrockEmbeddingModel,
+}
+
+impl EmbeddingModel {
+    pub fn new(client: Client, model: BedrockEmbeddingModel) -> Self {
+        Self { client, model }
+    }
+
+    pub async fn document_to_embeddings(
+        &self,
+        request: EmbeddingRequest,
+    ) -> Result<EmbeddingResponse, EmbeddingError> {
+        let input_document = serde_json::to_string(&request).map_err(EmbeddingError::JsonError)?;
+
+        let model_response = self
+            .client
+            .aws_client
+            .invoke_model()
+            .model_id(self.model.as_str())
+            .content_type("application/json")
+            .accept("application/json")
+            .body(Blob::new(input_document))
+            .send()
+            .await;
+
+        let response = model_response
+                    .map_err(|sdk_error| if let Some(service_error) = sdk_error.as_service_error() {
+                        let err: String = match service_error {
+                            InvokeModelError::ModelTimeoutException(e) => e.to_owned().message.unwrap_or("The request took too long to process. Processing time exceeded the model timeout length.".into()),
+                            InvokeModelError::AccessDeniedException(e) => e.to_owned().message.unwrap_or("The request is denied because you do not have sufficient permissions to perform the requested action.".into()),
+                            InvokeModelError::ResourceNotFoundException(e) => e.to_owned().message.unwrap_or("The specified resource ARN was not found.".into()),
+                            InvokeModelError::ThrottlingException(e) => e.to_owned().message.unwrap_or("Your request was denied due to exceeding the account quotas for Amazon Bedrock.".into()),
+                            InvokeModelError::ServiceUnavailableException(e) => e.to_owned().message.unwrap_or("The service isn't currently available.".into()),
+                            InvokeModelError::InternalServerException(e) => e.to_owned().message.unwrap_or("An internal server error occurred.".into()),
+                            InvokeModelError::ValidationException(e) => e.to_owned().message.unwrap_or("The input fails to satisfy the constraints specified by Amazon Bedrock.".into()),
+                            InvokeModelError::ModelNotReadyException(e) => e.to_owned().message.unwrap_or("The model specified in the request is not ready to serve inference requests. The AWS SDK will automatically retry the operation up to 5 times.".into()),
+                            InvokeModelError::ModelErrorException(e) => e.to_owned().message.unwrap_or("The request failed due to an error while processing the model.".into()),
+                            InvokeModelError::ServiceQuotaExceededException(e) => e.to_owned().message.unwrap_or("Your request exceeds the service quota for your account.".into()),
+                            _ => String::from("An unexpected error occurred (e.g., invalid JSON returned by the service or an unknown error code)."),
+                        };
+                        EmbeddingError::ProviderError(err)
+                    } else {
+                        EmbeddingError::ProviderError(format!("{:?}", sdk_error))
+                    })?;
+
+        let response_str = String::from_utf8(response.body.into_inner())
+            .map_err(|e| EmbeddingError::ResponseError(e.to_string()))?;
+
+        let result: EmbeddingResponse =
+            serde_json::from_str(&response_str).map_err(EmbeddingError::JsonError)?;
+
+        Ok(result)
+    }
+}
+
+impl embeddings::EmbeddingModel for EmbeddingModel {
+    const MAX_DOCUMENTS: usize = 1024;
+
+    fn ndims(&self) -> usize {
+        match self.model {
+            BedrockEmbeddingModel::TitanTextEmbeddingsV2(ndims) => ndims,
+            BedrockEmbeddingModel::Custom(_, ndims) => ndims,
+        }
+    }
+
+    async fn embed_texts(
+        &self,
+        documents: impl IntoIterator<Item = String> + Send,
+    ) -> Result<Vec<Embedding>, EmbeddingError> {
+        let documents: Vec<_> = documents.into_iter().collect();
+
+        let mut results = Vec::new();
+        let mut errors = Vec::new();
+
+        let mut iterator = documents.into_iter();
+        while let Some(embedding) = iterator.next().map(|doc| async move {
+            let request = EmbeddingRequest {
+                input_text: doc.to_owned(),
+                dimensions: self.ndims(),
+                normalize: true,
+            };
+            self.document_to_embeddings(request)
+                .await
+                .map(|embeddings| Embedding {
+                    document: doc.to_owned(),
+                    vec: embeddings.embedding,
+                })
+        }) {
+            match embedding.await {
+                Ok(embedding) => results.push(embedding),
+                Err(err) => errors.push(err),
+            }
+        }
+
+        match errors.as_slice() {
+            [] => Ok(results),
+            [err, ..] => Err(EmbeddingError::ResponseError(err.to_string())),
+        }
+    }
+}

--- a/rig-bedrock/src/lib.rs
+++ b/rig-bedrock/src/lib.rs
@@ -1,0 +1,152 @@
+pub mod client;
+pub mod completion;
+pub mod embedding;
+
+use aws_smithy_types::{Document, Number};
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+
+/// Convert a `aws_smithy_types::Document` into `serde_json::Value`
+pub fn document_to_json(doc: Document) -> Value {
+    match doc {
+        Document::Object(obj) => {
+            let documents = obj
+                .into_iter()
+                .map(|(k, v)| (k, document_to_json(v)))
+                .collect::<Map<_, _>>();
+            Value::Object(documents)
+        }
+        Document::Array(arr) => {
+            let documents = arr.into_iter().map(document_to_json).collect();
+            Value::Array(documents)
+        }
+        Document::Number(Number::PosInt(number)) => Value::Number(serde_json::Number::from(number)),
+        Document::Number(Number::NegInt(number)) => Value::Number(serde_json::Number::from(number)),
+        Document::Number(Number::Float(number)) => match serde_json::Number::from_f64(number) {
+            Some(n) => Value::Number(n),
+            // https://www.rfc-editor.org/rfc/rfc7159
+            // Numeric values that cannot be represented in the grammar (such as Infinity and NaN) are not permitted.
+            None => Value::Null,
+        },
+        Document::String(s) => Value::String(s),
+        Document::Bool(b) => Value::Bool(b),
+        Document::Null => Value::Null,
+    }
+}
+
+/// Convert a `serde_json::Value` into `aws_smithy_types::Document`
+pub fn json_to_document(value: Value) -> Document {
+    match value {
+        Value::Null => Document::Null,
+        Value::Bool(b) => Document::Bool(b),
+        Value::Number(num) => {
+            if let Some(i) = num.as_i64() {
+                match i > 0 {
+                    true => Document::Number(Number::PosInt(i as u64)),
+                    false => Document::Number(Number::NegInt(i)),
+                }
+            } else if let Some(f) = num.as_f64() {
+                Document::Number(Number::Float(f))
+            } else {
+                Document::Null
+            }
+        }
+        Value::String(s) => Document::String(s),
+        Value::Array(arr) => {
+            let documents = arr.into_iter().map(json_to_document).collect();
+            Document::Array(documents)
+        }
+        Value::Object(obj) => {
+            let documents = obj
+                .into_iter()
+                .map(|(k, v)| (k, json_to_document(v)))
+                .collect::<HashMap<_, _>>();
+            Document::Object(documents)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::document_to_json;
+    use super::json_to_document;
+    use aws_smithy_types::Document;
+    use serde_json::Value;
+
+    #[test]
+    fn test_json_to_document() {
+        let json = r#"
+            {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The first number to add"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The second number to add"
+                    }
+                },
+                "required":["x", "y"]
+            }
+        "#;
+
+        let value: Value = serde_json::from_str(json).unwrap();
+        let document = json_to_document(value);
+        println!("{:?}", document);
+    }
+
+    #[test]
+    fn test_document_to_json() {
+        let document = Document::Object(HashMap::from([
+            (
+                String::from("type"),
+                Document::String(String::from("object")),
+            ),
+            (
+                String::from("properties"),
+                Document::Object(HashMap::from([
+                    (
+                        String::from("x"),
+                        Document::Object(HashMap::from([
+                            (
+                                String::from("type"),
+                                Document::String(String::from("number")),
+                            ),
+                            (
+                                String::from("description"),
+                                Document::String(String::from("The first number to add")),
+                            ),
+                        ])),
+                    ),
+                    (
+                        String::from("y"),
+                        Document::Object(HashMap::from([
+                            (
+                                String::from("type"),
+                                Document::String(String::from("number")),
+                            ),
+                            (
+                                String::from("description"),
+                                Document::String(String::from("The second number to add")),
+                            ),
+                        ])),
+                    ),
+                ])),
+            ),
+            (
+                String::from("required"),
+                Document::Array(vec![
+                    Document::String(String::from("x")),
+                    Document::String(String::from("y")),
+                ]),
+            ),
+        ]));
+
+        let json = document_to_json(document);
+        println!("{:?}", json);
+    }
+}


### PR DESCRIPTION
This companion crate integrates AWS Bedrock as model provider with Rig.

ee the [`/examples`](./examples) folder for usage examples.
